### PR TITLE
Centos 7 addition of Vagrant setup files

### DIFF
--- a/centos7-1024mb/Vagrantfile
+++ b/centos7-1024mb/Vagrantfile
@@ -1,0 +1,18 @@
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |provider, override|
+    provider.name = "debian8-512mb"
+    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_version = "0.1"
+    provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    provider.memory = 1024
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.network "private_network", type: "dhcp"
+  #config.vm.network :private_network, ip: "172.28.128.128"
+end

--- a/centos7-1024mb/Vagrantfile
+++ b/centos7-1024mb/Vagrantfile
@@ -4,9 +4,9 @@
 
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider, override|
-    provider.name = "debian8-512mb"
-    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
-    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    provider.name = "centos7-1024mb"
+    override.vm.box = "terminal-labs/tl-centos-7-64bit-30gb"
+    override.vm.box_url = "terminal-labs/tl-centos-7-64bit-30gb"
     override.vm.box_version = "0.1"
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']

--- a/centos7-2048mb/Vagrantfile
+++ b/centos7-2048mb/Vagrantfile
@@ -1,0 +1,18 @@
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |provider, override|
+    provider.name = "debian8-512mb"
+    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_version = "0.1"
+    provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    provider.memory = 2048
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.network "private_network", type: "dhcp"
+  #config.vm.network :private_network, ip: "172.28.128.128"
+end

--- a/centos7-2048mb/Vagrantfile
+++ b/centos7-2048mb/Vagrantfile
@@ -4,9 +4,9 @@
 
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider, override|
-    provider.name = "debian8-512mb"
-    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
-    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    provider.name = "centos7-2048mb"
+    override.vm.box = "terminal-labs/tl-centos-7-64bit-40gb"
+    override.vm.box_url = "terminal-labs/tl-centos-7-64bit-40gb"
     override.vm.box_version = "0.1"
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']

--- a/centos7-4096mb/Vagrantfile
+++ b/centos7-4096mb/Vagrantfile
@@ -1,0 +1,18 @@
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |provider, override|
+    provider.name = "debian8-512mb"
+    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_version = "0.1"
+    provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    provider.memory = 4096
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.network "private_network", type: "dhcp"
+  #config.vm.network :private_network, ip: "172.28.128.128"
+end

--- a/centos7-4096mb/Vagrantfile
+++ b/centos7-4096mb/Vagrantfile
@@ -4,9 +4,9 @@
 
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider, override|
-    provider.name = "debian8-512mb"
-    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
-    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    provider.name = "centos7-4096mb"
+    override.vm.box = "terminal-labs/tl-centos-7-64bit-60gb"
+    override.vm.box_url = "terminal-labs/tl-centos-7-64bit-60gb"
     override.vm.box_version = "0.1"
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']

--- a/centos7-512mb/Vagrantfile
+++ b/centos7-512mb/Vagrantfile
@@ -1,0 +1,18 @@
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |provider, override|
+    provider.name = "centos7-512mb"
+    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box_version = "0.1"
+    provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    provider.memory = 512
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.network "private_network", type: "dhcp"
+  #config.vm.network :private_network, ip: "172.28.128.128"
+end

--- a/centos7-512mb/Vagrantfile
+++ b/centos7-512mb/Vagrantfile
@@ -5,8 +5,8 @@
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider, override|
     provider.name = "centos7-512mb"
-    override.vm.box = "terminal-labs/tl-debian-jessie-64bit-20gb"
-    override.vm.box_url = "terminal-labs/tl-debian-jessie-64bit-20gb"
+    override.vm.box = "terminal-labs/tl-centos-7-64bit-20gb"
+    override.vm.box_url = "terminal-labs/tl-centos-7-64bit-20gb"
     override.vm.box_version = "0.1"
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']

--- a/centos7-8192mb/Vagrantfile
+++ b/centos7-8192mb/Vagrantfile
@@ -1,0 +1,18 @@
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |provider, override|
+    provider.name = "centos7-8192mb"
+    override.vm.box = "terminal-labs/tl-centos-7-64bit-80gb"
+    override.vm.box_url = "terminal-labs/tl-centos-7-64bit-80gb"
+    override.vm.box_version = "0.1"
+    provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
+    provider.memory = 8192
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.network "private_network", type: "dhcp"
+  #config.vm.network :private_network, ip: "172.28.128.128"
+end


### PR DESCRIPTION
includes box sizes:
--RAM: 512mb, HDD/SSD: 20gb
--RAM: 1024mb, HDD/SSD: 30gb
--RAM: 2048mb, HDD/SSD: 40gb
--RAM: 4096mb, HDD/SSD: 60gb
--RAM: 8192mb, HDD/SSD: 80gb
